### PR TITLE
fix empty shop bug

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -27,6 +27,10 @@ Citizen.CreateThread(function()
 
 	ESX.TriggerServerCallback('esx_shops:requestDBItems', function(ShopItems)
 		for k,v in pairs(ShopItems) do
+			if (Config.Zones[k] == nil) then
+				Config.Zones[k] = {}		
+			end
+					
 			Config.Zones[k].Items = v
 		end
 	end)

--- a/client/main.lua
+++ b/client/main.lua
@@ -28,7 +28,10 @@ Citizen.CreateThread(function()
 	ESX.TriggerServerCallback('esx_shops:requestDBItems', function(ShopItems)
 		for k,v in pairs(ShopItems) do
 			if (Config.Zones[k] == nil) then
-				Config.Zones[k] = {}		
+				Config.Zones[k] = {
+					Items = {},
+					Pos = {}
+				}		
 			end
 					
 			Config.Zones[k].Items = v


### PR DESCRIPTION
When combined with mods that integrate with the shops mod, this mod does not account for them not being in the config.

The intermittence would depend on the order that the items were retrieved by the mod initially. If I were to get the zone that was not in the Config come through first, then all shops will break. If I were to get it in the middle, then some will break.

Example ExtraItems by HumanTree.

Fixes #33 and #13 